### PR TITLE
Add Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .config
 .yardoc
 .vagrant
+mutagen-node*.yml.lock
+Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/lib/vagrant-mutagen-project.rb
+++ b/lib/vagrant-mutagen-project.rb
@@ -1,5 +1,5 @@
-require "vagrant-mutagen-project/version"
-require "vagrant-mutagen-project/plugin"
+require 'vagrant-mutagen-project/version'
+require 'vagrant-mutagen-project/plugin'
 
 module VagrantPlugins
   module MutagenProject

--- a/lib/vagrant-mutagen-project/action/pause_mutagen_project.rb
+++ b/lib/vagrant-mutagen-project/action/pause_mutagen_project.rb
@@ -1,4 +1,4 @@
-require_relative "../mutagen"
+require_relative '../mutagen'
 
 module VagrantPlugins
   module MutagenProject
@@ -13,8 +13,8 @@ module VagrantPlugins
         end
 
         def call(env)
-          if is_enabled
-            @ui.info "[vagrant-mutagen-project] Pausing Mutagen sync"
+          if enabled?
+            @ui.info '[vagrant-mutagen-project] Pausing Mutagen sync'
             pause_project
           end
 

--- a/lib/vagrant-mutagen-project/action/resume_mutagen_project.rb
+++ b/lib/vagrant-mutagen-project/action/resume_mutagen_project.rb
@@ -1,4 +1,4 @@
-require_relative "../mutagen"
+require_relative '../mutagen'
 
 module VagrantPlugins
   module MutagenProject
@@ -13,8 +13,8 @@ module VagrantPlugins
         end
 
         def call(env)
-          if is_enabled
-            @ui.info "[vagrant-mutagen-project] Resuming Mutagen sync"
+          if enabled?
+            @ui.info '[vagrant-mutagen-project] Resuming Mutagen sync'
             resume_project
           end
 

--- a/lib/vagrant-mutagen-project/action/start_mutagen_project.rb
+++ b/lib/vagrant-mutagen-project/action/start_mutagen_project.rb
@@ -1,5 +1,5 @@
-require_relative "../mutagen"
-require_relative "../ssh_config"
+require_relative '../mutagen'
+require_relative '../ssh_config'
 
 module VagrantPlugins
   module MutagenProject
@@ -15,7 +15,7 @@ module VagrantPlugins
         end
 
         def call(env)
-          if is_enabled
+          if enabled?
             add_machine_to_ssh_config
             start_project
           end

--- a/lib/vagrant-mutagen-project/action/terminate_mutagen_project.rb
+++ b/lib/vagrant-mutagen-project/action/terminate_mutagen_project.rb
@@ -1,5 +1,5 @@
-require_relative "../mutagen"
-require_relative "../ssh_config"
+require_relative '../mutagen'
+require_relative '../ssh_config'
 
 module VagrantPlugins
   module MutagenProject
@@ -15,7 +15,7 @@ module VagrantPlugins
         end
 
         def call(env)
-          if is_enabled && is_destroy_confirmed(env)
+          if enabled? && destroy_confirmed?(env)
             terminate_project
             remove_machine_from_ssh_config
           end
@@ -23,7 +23,7 @@ module VagrantPlugins
           @app.call(env)
         end
 
-        def is_destroy_confirmed(env)
+        def destroy_confirmed?(env)
           env[:force_confirm_destroy_result]
         end
       end

--- a/lib/vagrant-mutagen-project/config.rb
+++ b/lib/vagrant-mutagen-project/config.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
 
       def finalize!
         @orchestrate = false if @orchestrate == UNSET_VALUE
-        @project_file = "mutagen.yml" if @project_file == UNSET_VALUE
+        @project_file = 'mutagen.yml' if @project_file == UNSET_VALUE
       end
     end
   end

--- a/lib/vagrant-mutagen-project/mutagen.rb
+++ b/lib/vagrant-mutagen-project/mutagen.rb
@@ -1,73 +1,68 @@
-require "shellwords"
+require 'shellwords'
+require 'open3'
 
 module VagrantPlugins
   module MutagenProject
     module Mutagen
-      def is_enabled()
+      def enabled?
         @machine.config.mutagen.orchestrate == true
       end
 
-      def start_daemon()
-        daemon_command = "mutagen daemon start"
+      def start_daemon
+        out, status = Open3.capture2e('mutagen daemon start')
+        return if status.success?
 
-        unless system(daemon_command)
-          @ui.error "[vagrant-mutagen-project] Failed to start mutagen daemon"
-        end
+        @ui.error "[vagrant-mutagen-project] Failed to start mutagen daemon: #{out}"
       end
 
-      def start_project()
-        project_file = @machine.config.mutagen.project_file
+      def start_project
         start_daemon
 
-        project_started_command = "mutagen project list -f %s >/dev/null 2>/dev/null" % [Shellwords.escape(project_file)]
-        project_start_command = "mutagen project start -f %s" % [Shellwords.escape(project_file)]
-        project_status_command = "mutagen project list -f %s" % [Shellwords.escape(project_file)]
+        project_file = @machine.config.mutagen.project_file
+        escaped_project_file = Shellwords.escape(project_file)
 
-        unless system(project_started_command) # mutagen project list returns 1 on error when no project is started
-          @ui.info "[vagrant-mutagen-project] Starting mutagen project orchestration (config: %s)" % project_file
+        _, status = Open3.capture2e("mutagen project list -f #{escaped_project_file}")
+        return if status.success?
 
-          unless system(project_start_command)
-            @ui.error "[vagrant-mutagen-project] Failed to start mutagen project (see error above)"
-          end
-        end
+        @ui.info "[vagrant-mutagen-project] Starting mutagen project orchestration (config: #{project_file})"
+        out, status = Open3.capture2e("mutagen project start -f #{escaped_project_file}")
+        return if status.success?
 
-        system(project_status_command) # show project status to indicate if there are conflicts
+        @ui.error "[vagrant-mutagen-project] Failed to start mutagen project: #{out}"
       end
 
-      def terminate_project()
+      def terminate_project
         project_file = @machine.config.mutagen.project_file
+        escaped_project_file = Shellwords.escape(project_file)
 
-        project_started_command = "mutagen project list -f %s >/dev/null 2>/dev/null" % [Shellwords.escape(project_file)]
-        project_terminate_command = "mutagen project terminate -f %s" % [Shellwords.escape(project_file)]
-        project_status_command = "mutagen project list -f %s 2>/dev/null" % [Shellwords.escape(project_file)]
+        _, status = Open3.capture2e("mutagen project list -f #{escaped_project_file}")
+        return unless status.success?
 
-        if system(project_started_command) # mutagen project list returns 1 on error when no project is started
-          @ui.info "[vagrant-mutagen-project] Stopping mutagen project orchestration"
+        @ui.info '[vagrant-mutagen-project] Stopping mutagen project orchestration'
+        out, status = Open3.capture2e("mutagen project terminate -f #{escaped_project_file}")
+        return if status.success?
 
-          unless system(project_terminate_command)
-            @ui.error "[vagrant-mutagen-project] Failed to stop mutagen project (see error above)"
-          end
-        end
-
-        system(project_status_command)
+        @ui.error "[vagrant-mutagen-project] Failed to terminate mutagen project: #{out}"
       end
 
       def pause_project
         project_file = @machine.config.mutagen.project_file
+        escaped_project_file = Shellwords.escape(project_file)
 
-        pause_project_command = "mutagen project pause -f %s" % [Shellwords.escape(project_file)]
-        unless system(pause_project_command)
-          @ui.error "[vagrant-mutagen-project] Failed to pause mutagen project"
-        end
+        out, status = Open3.capture2e("mutagen project pause -f #{escaped_project_file}")
+        return if status.success?
+
+        @ui.error "[vagrant-mutagen-project] Failed to pause mutagen project: #{out}"
       end
 
       def resume_project
         project_file = @machine.config.mutagen.project_file
+        escaped_project_file = Shellwords.escape(project_file)
 
-        resume_project_command = "mutagen project resume -f %s" % [Shellwords.escape(project_file)]
-        unless system(resume_project_command)
-          @ui.error "[vagrant-mutagen-project] Failed to resume mutagen project"
-        end
+        out, status = Open3.capture2e("mutagen project resume -f #{escaped_project_file}")
+        return if status.success?
+
+        @ui.error "[vagrant-mutagen-project] Failed to resume mutagen project: #{out}"
       end
     end
   end

--- a/lib/vagrant-mutagen-project/plugin.rb
+++ b/lib/vagrant-mutagen-project/plugin.rb
@@ -1,8 +1,8 @@
-require "vagrant-mutagen-project/action/start_mutagen_project"
-require "vagrant-mutagen-project/action/pause_mutagen_project"
-require "vagrant-mutagen-project/action/resume_mutagen_project"
-require "vagrant-mutagen-project/action/terminate_mutagen_project"
-require "yaml"
+require 'vagrant-mutagen-project/action/start_mutagen_project'
+require 'vagrant-mutagen-project/action/pause_mutagen_project'
+require 'vagrant-mutagen-project/action/resume_mutagen_project'
+require 'vagrant-mutagen-project/action/terminate_mutagen_project'
+require 'yaml'
 
 module VagrantPlugins
   module MutagenProject

--- a/lib/vagrant-mutagen-project/ssh_config.rb
+++ b/lib/vagrant-mutagen-project/ssh_config.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
       SSH_CONFIG_DIR = File.dirname(SSH_CONFIG_PATH)
 
       def add_machine_to_ssh_config
-        @ui.info '[vagrant-mutagen-project] Checking for SSH config entries'
+        @ui.info '[vagrant-mutagen-project] Adding machine to SSH config'
 
         # Ensure the full path exists
         FileUtils.mkdir_p(SSH_CONFIG_DIR)
@@ -34,7 +34,7 @@ module VagrantPlugins
       end
 
       def remove_machine_from_ssh_config
-        @ui.info '[vagrant-mutagen-project] Removing SSH config entry'
+        @ui.info '[vagrant-mutagen-project] Removing machine from SSH config'
 
         if File.exists?(SSH_CONFIG_PATH)
           File.open(SSH_CONFIG_PATH, File::LOCK_EX | File::RDWR) do |file|

--- a/mutagen-node1.yml
+++ b/mutagen-node1.yml
@@ -6,6 +6,8 @@ sync:
     flushOnCreate: true
     ignore:
       vcs: true
+      paths:
+          - '*.yml.lock'
     configurationBeta:
       permissions:
         defaultOwner: vagrant

--- a/mutagen-node2.yml
+++ b/mutagen-node2.yml
@@ -6,6 +6,8 @@ sync:
     flushOnCreate: true
     ignore:
       vcs: true
+      paths:
+          - '*.yml.lock'
     configurationBeta:
       permissions:
         defaultOwner: vagrant

--- a/mutagen-node3.yml
+++ b/mutagen-node3.yml
@@ -6,6 +6,8 @@ sync:
     flushOnCreate: true
     ignore:
       vcs: true
+      paths:
+          - '*.yml.lock'
     configurationBeta:
       permissions:
         defaultOwner: vagrant


### PR DESCRIPTION
Add support, tested with Windows 10 by capturing the stdout and stderr outputs from mutagen command execution within open3 library rather than redirecting to /dev/null.

To avoid a deadlock, the mutagen lock file must be added to the mutagen ignored paths list for Windows support to work.